### PR TITLE
fix para sqrt() que retornaba 0 cuando no se incluia el operando

### DIFF
--- a/src/lib/getOperatings.js
+++ b/src/lib/getOperatings.js
@@ -30,12 +30,14 @@ export const getSingleOperating = ([leftSide, rightSide]) => {
     // Extraemos el contenido de los paréntesis y validamos
     // que sea un número válido
     let firstOperating = rightSide.slice(1, -1);
+
+    // Comprobamos el caracter vacío ya que al convertirlo sería un 0
+    if (firstOperating === '') throw new InvalidInputError();
+    
     firstOperating = Number(firstOperating.replaceAll(',', '.'));
 
     if (isNaN(firstOperating) || !isFinite(firstOperating))
         throw new InvalidInputError();
-
-    if (!firstOperating) throw new InvalidInputError();
 
     return [firstOperating];
 };

--- a/src/lib/getOperatings.js
+++ b/src/lib/getOperatings.js
@@ -35,5 +35,7 @@ export const getSingleOperating = ([leftSide, rightSide]) => {
     if (isNaN(firstOperating) || !isFinite(firstOperating))
         throw new InvalidInputError();
 
+    if (!firstOperating) throw new InvalidInputError();
+
     return [firstOperating];
 };


### PR DESCRIPTION
al escribir sqrt() la operación continuaba normalmente y retornaba "el resultado es 0", siendo que log() funcionaba correctamente
![2022-08-19_16-18](https://user-images.githubusercontent.com/54788838/185701174-bc607113-bf9c-4199-a909-bb32561163f9.png)

este pequeño fix arregla dicho error
![2022-08-19_16-18_1](https://user-images.githubusercontent.com/54788838/185701263-0cfe6fb0-109a-4a8a-8fb6-86c3d9dded20.png)

