### PR TITLE
🐛 Fix exponential operator

### DIFF
--- a/src/constants/operations.js
+++ b/src/constants/operations.js
@@ -3,7 +3,7 @@ export const operations = {
     '-': (firstOperating, secondOperating) => firstOperating - secondOperating,
     '*': (firstOperating, secondOperating) => firstOperating * secondOperating,
     '/': (firstOperating, secondOperating) => firstOperating / secondOperating,
-    '^': (firstOperating, secondOperating) => firstOperating ^ secondOperating,
+    '^': (firstOperating, secondOperating) => firstOperating ** secondOperating,
     log: (operating) => Math.log10(operating),
     sqrt: (operating) => Math.sqrt(operating),
 };


### PR DESCRIPTION
El operador ^ (potencia/exponente) esta mal:

![fix1](https://user-images.githubusercontent.com/88177467/192671476-fcdd2fc0-8e97-4d85-bdb6-c7442bd8c431.png)

El problema se encuentra aquí:

![fix2](https://user-images.githubusercontent.com/88177467/192671953-f0bcdaa1-3286-4b18-986f-12260cd6976c.png)
No se exactamente como funciona el operador XOR pero estoy casi seguro que no saca el exponente a ningún numero.
Aquí la doc: [OPERADOR XOR](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_XOR)

Ahora todo funciona correctamente:

![fix3](https://user-images.githubusercontent.com/88177467/192672663-2b45ca2d-4e3d-439c-8549-3fb13233f38b.png)
